### PR TITLE
Generalized script to any executable, added intuitive error checking

### DIFF
--- a/hat240.sh
+++ b/hat240.sh
@@ -56,22 +56,18 @@ bar_length=${#bar}
 echo
 
 for i in `seq 1 $test_count`; do
-    # checks for directory 
-    if [ ! -d "failure$tests_failed" ]; then
-        mkdir "failure$tests_failed"
-    fi
-
+    mkdir "failure$tests_failed"
+    
     # move into test failed and copy test file
     cd "failure$tests_failed"
-    cp ../../$homework_test_file test_file
 
     # execute and calculate score
-    $(./test_file > test_output.txt)
+    $(../../$homework_test_file > ./test_output.txt)
     score=$(cat test_output.txt | grep "total score" | grep -E -o "[0-9]+")
 
     if [ $score -eq $target_score ] || [ $score -gt $target_score ]; then
         cd ..
-	rm -rf "Failure$tests_failed"
+	rm -rf "failure$tests_failed"
     else
         echo "Failure$tests_failed: $score" >> "../failures.txt"
 
@@ -81,7 +77,6 @@ for i in `seq 1 $test_count`; do
         fi
 
         tests_failed=$((tests_failed + 1))
-	rm test_file
 	cd ..
     fi
     n=$(((i)*bar_length / test_count))
@@ -94,8 +89,8 @@ echo
 echo "$tests_failed tests failed!"
 
 if [ $tests_failed = 0 ]; then
+    cd ..
     rm -rf test_failures
-    echo "Congratulations! (You can submit with 'make submit')"
 else
     echo "Lowest Score: $minimum_score in failure$minimum_score_failure"
 fi

--- a/hat240.sh
+++ b/hat240.sh
@@ -8,7 +8,6 @@
 # $1 = Test File
 # $2 = Test Count
 # $3 = Target Score
-# $4 = Files For Saving on Failure
 #
 
 if [ -z "$1" ]; then
@@ -16,43 +15,61 @@ if [ -z "$1" ]; then
 else
     homework_test_file=$1
 fi
+
+if [ ! -f $homework_test_file ]; then
+    echo "File not found. Please ensure you have the correct path."
+    exit 1
+fi
+
 if [ -z "$2" ]; then
     read -e -p "How many times would you like to test? " test_count
 else
     test_count=$2
 fi
+
+if [ $test_count -le 0 ]; then
+    echo "Can't execute less than 1 time"
+    exit 1
+fi
+
 if [ -z "$3" ]; then
     target_score=100
 else
     target_score=$3
-fi
-if [ -z "$4" ]; then
-    files_for_saving="*Bogus* *Input* *Output* *Result*"
-else
-    files_for_saving=$4
 fi
 
 tests_failed=0
 minimum_score=100
 minimum_score_failure=0
 
-rm -rf test_failures
-
-mkdir -p test_failures
+if [ -d test_failures ]; then
+    rm -rf test_failures/*
+else
+    mkdir -p test_failures
+fi
 touch "test_failures/failures.txt"
 
+cd test_failures
+
+bar="=============================="
+bar_length=${#bar}
+echo
+
 for i in `seq 1 $test_count`; do
-    $($homework_test_file > test_output.txt)
+    # checks for 
+    if [ ! -d "failure$tests_failed" ]; then
+        mkdir "failure$tests_failed"
+    fi
+    cd "failure$tests_failed"
+    cp ../../$homework_test_file test_file
+    $(./test_file > test_output.txt)
     score=$(cat test_output.txt | grep "total score" | grep -E -o "[0-9]+")
 
-    if [ $score = $target_score ] || [ $score -gt $target_score ]; then
-        rm -f $files_for_saving
+    if [ $score -eq $target_score ] || [ $score -gt $target_score ]; then
+        cd ..
+	rm -rf "Failure$tests_failed"
     else
-        mkdir "test_failures/failure$tests_failed"
-        mv -f $files_for_saving "test_failures/failure$tests_failed" 2>/dev/null
-        mv -f test_output.txt "test_failures/failure$tests_failed/failure_test_output.txt"
-
-        echo "Failure$tests_failed: $score" >> "test_failures/failures.txt"
+        echo "Failure$tests_failed: $score" >> "../failures.txt"
 
         if [ $score -lt $minimum_score ]; then
             minimum_score=$score;
@@ -60,20 +77,21 @@ for i in `seq 1 $test_count`; do
         fi
 
         tests_failed=$((tests_failed + 1))
+	rm test_file
+	cd ..
     fi
-
-    if [ $(($test_count / 20)) -gt 0 ] && [ $(($i % ($test_count / 20))) = 0 ]; then
-        printf "."
-    fi
+    n=$(((i)*bar_length / test_count))
+    printf "\r[%-${bar_length}s] #%d" "${bar:0:n}" $((i))
+   
 done
 
-rm -f test_output.txt
-
+echo
 echo
 echo "$tests_failed tests failed!"
 
 if [ $tests_failed = 0 ]; then
     rm -rf test_failures
+    echo "Congratulations! (You can submit with 'make submit')"
 else
     echo "Lowest Score: $minimum_score in failure$minimum_score_failure"
 fi

--- a/hat240.sh
+++ b/hat240.sh
@@ -56,12 +56,16 @@ bar_length=${#bar}
 echo
 
 for i in `seq 1 $test_count`; do
-    # checks for 
+    # checks for directory 
     if [ ! -d "failure$tests_failed" ]; then
         mkdir "failure$tests_failed"
     fi
+
+    # move into test failed and copy test file
     cd "failure$tests_failed"
     cp ../../$homework_test_file test_file
+
+    # execute and calculate score
     $(./test_file > test_output.txt)
     score=$(cat test_output.txt | grep "total score" | grep -E -o "[0-9]+")
 


### PR DESCRIPTION
Have a look at the changes; I altered the script so instead of running the executable in the test_failures directory, the script cds into the subdirectories of test_failures, so it can be applied to any assignment regardless of the names of files it generates. I haven't done much work with bash optimization, so its possible the changes could make it run slower.
I included checking for invalid file paths and the user trying to run the script 0 or fewer times as well as the progress indicator from the script I wrote previously.

This script is far better in the ease of use category than the one I wrote, and thank you for designing it, containing each failure in it's own directory is a good idea.